### PR TITLE
Multiple JMX instance plugins

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook which configures collectd plugins.'
 long_description 'Application cookbook which configures collectd plugins.'
-version '2.0.3'
+version '2.0.4'
 source_url 'https://github.com/bloomberg/collectd_plugins-cookbook'
 issues_url 'https://github.com/bloomberg/collectd_plugins-cookbook/issues'
 

--- a/recipes/jmx.rb
+++ b/recipes/jmx.rb
@@ -11,7 +11,7 @@ include_recipe 'collectd::default'
 # This recipe will create a collectd_plugin_file for each jmx 'instance' that
 # has been configured in node. Service user, group, and directory are reused,
 # but individual jmx instances set their cookbook, source, and variable hashes
-# seperately. 
+# seperately
 
 node['collectd_plugins']['jmx'].each do |instance, config|
   collectd_plugin_file "jmx_#{instance}_config" do

--- a/recipes/jmx.rb
+++ b/recipes/jmx.rb
@@ -5,15 +5,24 @@
 # Copyright 2010, Atari, Inc
 # Copyright 2015, Bloomberg Finance L.P.
 #
+
 include_recipe 'collectd::default'
 
-collectd_plugin_file 'jmx' do
-  user node['collectd']['service_user']
-  group node['collectd']['service_group']
-  directory node['collectd']['service']['config_directory']
-  plugin_instance_name node['collectd-plugins']['jmx']['plugin_instance_name']
-  cookbook node['collectd-plugins']['jmx']['cookbook']
-  source node['collectd-plugins']['jmx']['source']
-  variables node['collectd-plugins']['jmx']['variables'].merge('hostname' => node['fqdn'])
-  notifies :restart, "collectd_service[#{node['collectd']['service_name']}]", :delayed
+# This recipe will create a collectd_plugin_file for each jmx 'instance' that
+# has been configured in node. Service user, group, and directory are reused,
+# but individual jmx instances set their cookbook, source, and variable hashes
+# seperately. 
+
+node['collectd_plugins']['jmx'].each do |instance, config|
+  collectd_plugin_file "jmx_#{instance}_config" do
+    user node['collectd']['service_user']
+    group node['collectd']['service_group']
+    directory node['collectd']['service']['config_directory']
+
+    plugin_instance_name instance
+    cookbook  config['cookbook']
+    source    config['source']
+    variables config['variables'].merge('hostname' => node['fqdn'])
+    notifies :restart, "collectd_service[#{node['collectd']['service_name']}]", :delayed
+  end
 end


### PR DESCRIPTION
The version currently on master only will only allow one component to set a jmx config file per chef run. Whichever attribute/recipe sets collectd-plugins/jmx/variables last.

I've modified the recipe to loop through multiple jmx 'instances' instead of just one. Individual components will have to set their jmx settings one level lower, inside an 'instance' hash.

Since the version on master was broken anyways, I didn't up the minor version. Figured patch was good enough but let me know if you'd prefer a different version bump.
