### PR TITLE
Use a hash for jmx default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,4 +13,4 @@ default['collectd-plugins']['interface']['ignore_selected'] = true
 default['collectd-plugins']['df']['report_reserved'] = false
 default['collectd-plugins']['df']['ignore_selected'] = true
 default['collectd-plugins']['df']['f_s_type'] = %w(proc sysfs fusectl debugfs securityfs devtmpfs devpts tmpfs)
-default['collectd_plugins']['jmx'] = []
+default['collectd_plugins']['jmx'] = {}

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook which configures collectd plugins.'
 long_description 'Application cookbook which configures collectd plugins.'
-version '2.0.6'
+version '2.0.7'
 source_url 'https://github.com/bloomberg/collectd_plugins-cookbook'
 issues_url 'https://github.com/bloomberg/collectd_plugins-cookbook/issues'
 


### PR DESCRIPTION
We were getting `no implicit conversion of String into Integer`
`26>> node.default['collectd_plugins']['jmx']['ipmon-hadoop-hfds-datanode']['cookbook'] = 'ipmon-hadoop'`

I believe this is because the '[]' operator was trying to index into the arry rather than overriding it. Defaulting to a hash should fix this.
