### PR TITLE
Adding processes plugin recipe

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook which configures collectd plugins.'
 long_description 'Application cookbook which configures collectd plugins.'
-version '2.0.7'
+version '2.1.0'
 source_url 'https://github.com/bloomberg/collectd_plugins-cookbook'
 issues_url 'https://github.com/bloomberg/collectd_plugins-cookbook/issues'
 

--- a/recipes/processes.rb
+++ b/recipes/processes.rb
@@ -1,0 +1,15 @@
+#
+# Cookbook: collectd_plugins
+# License: Apache 2.0
+#
+# Copyright 2015, Bloomberg Finance L.P.
+#
+include_recipe 'collectd::default'
+
+collectd_plugin 'processes' do
+  user node['collectd']['service_user']
+  group node['collectd']['service_group']
+  directory node['collectd']['service']['config_directory']
+  options node['collectd-plugins']['processes']
+  notifies :restart, "collectd_service[#{node['collectd']['service_name']}]", :delayed
+end


### PR DESCRIPTION
We're looking to start using the 'processes' plugin to capture fork rate and the total number of processes running on a machine.

Adding a recipe to configure that plugin. Bumping minor version.
