### PR TITLE
add python_file

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook which configures collectd plugins.'
 long_description 'Application cookbook which configures collectd plugins.'
-version '2.1.3'
+version '2.1.4'
 source_url 'https://github.com/bloomberg/collectd_plugins-cookbook'
 issues_url 'https://github.com/bloomberg/collectd_plugins-cookbook/issues'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Application cookbook which configures collectd plugins.'
 long_description 'Application cookbook which configures collectd plugins.'
-version '2.1.4'
+version '2.2.0'
 source_url 'https://github.com/bloomberg/collectd_plugins-cookbook'
 issues_url 'https://github.com/bloomberg/collectd_plugins-cookbook/issues'
 

--- a/recipes/python_file.rb
+++ b/recipes/python_file.rb
@@ -14,7 +14,7 @@ include_recipe 'collectd::default'
 # seperately
 unless node['collectd_plugins']['python_file'].empty?
   node['collectd_plugins']['python_file'].each do |instance, config|
-    collectd_plugin_file "python_file" do
+    collectd_plugin_file 'python_file' do
       user node['collectd']['service_user']
       group node['collectd']['service_group']
       directory node['collectd']['service']['config_directory']

--- a/recipes/python_file.rb
+++ b/recipes/python_file.rb
@@ -1,0 +1,29 @@
+#
+# Cookbook: collectd_plugins
+# License: Apache 2.0
+#
+# Copyright 2010, Atari, Inc
+# Copyright 2015, Bloomberg Finance L.P.
+#
+
+include_recipe 'collectd::default'
+
+# This recipe will create a collectd_plugin_file for each python 'instance' that
+# has been configured in node. Service user, group, and directory are reused,
+# but individual python instances set their cookbook, source, and variable hashes
+# seperately
+unless node['collectd_plugins']['python_file'].empty?
+  node['collectd_plugins']['python_file'].each do |instance, config|
+    collectd_plugin_file "python_file" do
+      user node['collectd']['service_user']
+      group node['collectd']['service_group']
+      directory node['collectd']['service']['config_directory']
+
+      plugin_instance_name instance
+      cookbook  config['cookbook']
+      source    config['source']
+      variables config['variables']
+      notifies :restart, "collectd_service[#{node['collectd']['service_name']}]", :delayed
+    end
+  end
+end


### PR DESCRIPTION
@yogeswaran
@johnbellone
```<Plugin "python">
	ModulePath "/........../collectd.d/python.d"
	Import "xyz_collector"
	LogTraces "true"
	Interactive "false"
	<Module "xyz_collector">
		Name "xyz-read-1"
		Port 4300
	</Module>
	<Module "xyz_collector">
		Name "xyz-write-1"
		Port 4400
	</Module>
</Plugin>```
Needed to support multiple "Module"' section for the python plugin.  Today, declaring an array of hashes in the recipe does not produce the result above.